### PR TITLE
#13 - auto-incremental version tagging

### DIFF
--- a/.github/workflows/auto-tagging.yml
+++ b/.github/workflows/auto-tagging.yml
@@ -1,0 +1,28 @@
+name: Bump version
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  build:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: '0'
+
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.67.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          PRERELEASE: false
+          TAG_CONTEXT: branch
+          DEFAULT_BUMP: patch


### PR DESCRIPTION
## GitHub action job for auto-tagging upon merged pull requests.
### How it works:
```mermaid
graph TD
A[Pull request] -- Merged --> B[main] -- Triggers job --> C[Auto-tagging action] -- Based on the commit message,<br/> it checks which segment <br/>needs to be updated --> D{Multi-commit?} -- Yes --> E[New commit on main <br/>that refers to the original PR <br/>and contains the new tag]
D{Multi-commit?} -- No --> F[Tags commit on main]
```
The default tagging segment is 'patch', thus if no explicit version bump is requested, the last segment will be updated.
e.g.: `0.1.3` -> `0.1.4`

### How to use it:
- Updating the **PATCH** (last) segment is the default, no further action is needed.
- Updating the **MINOR** (middle) segment: the commit message must contain the following `#minor` tag.
- Updating the **MAJOR** (first) segment: the commit message must contain the following `#major` tag.

### Limitations/issues
Currently, if a merged PR contains multiple commits then those commits won't get tagged, but a new commit will be created automatically that will refer to the original PR and this new commit will have the new version tag. Therefore, I'd embrace the single-commit per PR approach to avoid untagged commits on `main`.