### PR TITLE
#23 - remove sign up button from main welcome screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ migrate_working_dir/
 
 coverage/
 
+config/
+
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -125,7 +125,7 @@ class MyAppState extends State<MyApp> with WidgetsBindingObserver {
             colorScheme: ColorScheme.fromSwatch().copyWith(
                 secondary: const Color(colorPrimary),
                 brightness: Brightness.dark)),
-        debugShowCheckedModeBanner: false,
+        debugShowCheckedModeBanner: const bool.fromEnvironment("DEBUG_MODE"),
         color: const Color(colorPrimary),
         home: const LauncherScreen());
   }

--- a/lib/services/helper.dart
+++ b/lib/services/helper.dart
@@ -117,9 +117,11 @@ pushReplacement(BuildContext context, Widget destination) {
       .pushReplacement(MaterialPageRoute(builder: (context) => destination));
 }
 
-push(BuildContext context, Widget destination) {
-  Navigator.of(context)
-      .push(MaterialPageRoute(builder: (context) => destination));
+push(BuildContext context, Widget destination, bool enabled) {
+  if (enabled) {
+    Navigator.of(context)
+        .push(MaterialPageRoute(builder: (context) => destination));
+  }
 }
 
 pushAndRemoveUntil(BuildContext context, Widget destination, bool predict) {

--- a/lib/ui/auth/login/login_screen.dart
+++ b/lib/ui/auth/login/login_screen.dart
@@ -9,6 +9,9 @@ import 'package:kisgeri24/ui/home/date_time_picker_screen.dart';
 import 'package:kisgeri24/ui/home/home_screen.dart';
 import 'package:kisgeri24/ui/loading_cubit.dart';
 
+const bool ENABLED = true;
+const bool DISABLED = !ENABLED;
+
 class LoginScreen extends StatefulWidget {
   const LoginScreen({Key? key}) : super(key: key);
 
@@ -211,7 +214,7 @@ class ForgotPasswordWidget extends StatelessWidget {
         child: Align(
           alignment: Alignment.centerRight,
           child: GestureDetector(
-            onTap: () => push(context, const ResetPasswordScreen()),
+            onTap: () => push(context, const ResetPasswordScreen(), ENABLED),
             child: const Text(
               'Forgot password?',
               style: TextStyle(

--- a/lib/ui/auth/welcome/welcome_screen.dart
+++ b/lib/ui/auth/welcome/welcome_screen.dart
@@ -20,10 +20,11 @@ class WelcomeScreen extends StatelessWidget {
               listener: (context, state) {
                 switch (state.pressTarget) {
                   case WelcomePressTarget.login:
-                    push(context, const LoginScreen());
+                    push(context, const LoginScreen(), ENABLED);
                     break;
                   case WelcomePressTarget.signup:
-                    push(context, const SignUpScreen());
+                    push(context, const SignUpScreen(),
+                        isRegistrationFeatureEnabled());
                     break;
                   default:
                     break;
@@ -32,20 +33,7 @@ class WelcomeScreen extends StatelessWidget {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 crossAxisAlignment: CrossAxisAlignment.center,
-                children: <Widget>[
-                  Center(
-                    child: Image.asset(
-                      'assets/images/welcome_image.png',
-                      width: 150.0,
-                      height: 150.0,
-                      fit: BoxFit.cover,
-                    ),
-                  ),
-                  const WelcomeWidget(),
-                  const SubTitleWelcomeWidget(),
-                  const LogInButtonWidget(),
-                  const SignUpButtonWidget()
-                ],
+                children: getScreenComponents(),
               ),
             ),
           );
@@ -53,6 +41,31 @@ class WelcomeScreen extends StatelessWidget {
       ),
     );
   }
+}
+
+List<Widget> getScreenComponents() {
+  List<Widget> ws = [
+    Center(
+      key: const Key("value"),
+      child: Image.asset(
+        'assets/images/welcome_image.png',
+        width: 150.0,
+        height: 150.0,
+        fit: BoxFit.cover,
+      ),
+    ),
+    const WelcomeWidget(),
+    const SubTitleWelcomeWidget(),
+    const LogInButtonWidget()
+  ];
+  if (isRegistrationFeatureEnabled()) {
+    ws.add(const SignUpButtonWidget());
+  }
+  return ws;
+}
+
+bool isRegistrationFeatureEnabled() {
+  return const bool.fromEnvironment("REGISTRATION_ENABLED");
 }
 
 class SignUpButtonWidget extends StatelessWidget {


### PR DESCRIPTION
depends on #18, please **DO NOT MERGE** until the version tagging pr isn't on `main`

#### One can re-enable this feature by specifying the `REGISTRATION_ENABLED` environment variable as `true` at app compilation time (or add this value to the compiled config files later on, but that's not as future-proof since they can be overwritten time-by-time automatically)