### PR TITLE
#28 - disable verification jobs for merged commits

### DIFF
--- a/.github/workflows/main-dart.yml
+++ b/.github/workflows/main-dart.yml
@@ -1,8 +1,6 @@
 name:
   Dart
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
it is not necessary to run them again, since upon merge they should be green anyway