### PR TITLE
#101 - update Routes collection with route bolt equipment field

### DIFF
--- a/lib/data/converter/route_route_dto_converter.dart
+++ b/lib/data/converter/route_route_dto_converter.dart
@@ -14,8 +14,7 @@ class RouteToRouteDtoConverter extends Converter<Route, RouteDto> {
       input.ordinal,
       input.difficulty.toString() + input.diffchanger,
       input.points,
-      RouteEquipment
-          .bolted, // TODO: the designated collection has to be updated with this value (issue #101)
+      RouteEquipment.fromString(input.equipment),
     );
   }
 }

--- a/lib/data/dto/route_equipment.dart
+++ b/lib/data/dto/route_equipment.dart
@@ -6,7 +6,7 @@ enum RouteEquipment {
 
   const RouteEquipment(this.shorthand);
 
-  RouteEquipment fromString(String equipment) {
+  static RouteEquipment fromString(String equipment) {
     switch (equipment) {
       case "N":
         return RouteEquipment.bolted;

--- a/lib/data/models/route.dart
+++ b/lib/data/models/route.dart
@@ -9,6 +9,7 @@ class Route extends Entity {
   int key;
   int ordinal;
   int difficulty;
+  String equipment;
   String diffchanger;
 
   Route({
@@ -19,6 +20,7 @@ class Route extends Entity {
     int? key,
     int? ordinal,
     int? difficulty,
+    String? equipment,
     String? diffchanger,
   })  : name = name ?? unsetString,
         id = id ?? unsetString,
@@ -27,6 +29,7 @@ class Route extends Entity {
         key = key ?? 0,
         ordinal = ordinal ?? unsetInt,
         difficulty = difficulty ?? 0,
+        equipment = equipment ?? unsetString,
         diffchanger = diffchanger ?? unsetString;
 
   static Route fromSnapshot(value) {
@@ -38,6 +41,7 @@ class Route extends Entity {
     int keyHere = 0;
     int ordinal = unsetInt;
     int difficulty = 0;
+    String equipment = unsetString;
     String diffchanger = unsetString;
 
     routeMap.forEach((key, value) {
@@ -55,8 +59,9 @@ class Route extends Entity {
         ordinal = value as int;
       } else if (key == 'difficulty') {
         difficulty = value;
-      }
-      if (key == 'diffchanger') {
+      } else if (key == 'equipment') {
+        equipment = value;
+      } else if (key == 'diffchanger') {
         diffchanger = value;
       }
     });
@@ -69,6 +74,7 @@ class Route extends Entity {
         key: keyHere,
         ordinal: ordinal,
         difficulty: difficulty,
+        equipment: equipment,
         diffchanger: diffchanger);
     return route;
   }
@@ -84,6 +90,7 @@ class Route extends Entity {
           length == other.length &&
           key == other.key &&
           difficulty == other.difficulty &&
+          equipment == other.equipment &&
           diffchanger == other.diffchanger;
 
   @override
@@ -94,6 +101,7 @@ class Route extends Entity {
       length.hashCode ^
       key.hashCode ^
       difficulty.hashCode ^
+      equipment.hashCode ^
       diffchanger.hashCode;
 
   @override

--- a/test/data/converter/route_route_dto_converter_test.dart
+++ b/test/data/converter/route_route_dto_converter_test.dart
@@ -13,27 +13,52 @@ void main() {
 }
 
 void testConvert() {
-  test('Convert', () {
+  test('Convert for bolted route', () {
     underTest = RouteToRouteDtoConverter();
-    Route entity = new Route(
-      name: 'routeName',
-      id: "routeId",
-      points: 123,
-      length: 30,
-      key: 1,
-      ordinal: testOrdinal,
-      difficulty: 6,
-      diffchanger: "+",
-    );
+    Route entity = TestUtils.createRoute(quantity: 1).first;
+    entity.equipment = "N";
+
     RouteDto expected = new RouteDto(
       entity.name,
       entity.ordinal,
       entity.difficulty.toString() + entity.diffchanger,
       entity.points,
-      RouteEquipment
-          .bolted, // this needs to be updated once the issue #101 is resolved
+      RouteEquipment.bolted,
     );
 
     expect(underTest.convert(entity) == expected, true);
+  });
+  test('Convert for clean/trad route', () {
+    underTest = RouteToRouteDtoConverter();
+    Route entity = TestUtils.createRoute(quantity: 1).first;
+    entity.equipment = "C";
+    RouteDto expected = new RouteDto(
+      entity.name,
+      entity.ordinal,
+      entity.difficulty.toString() + entity.diffchanger,
+      entity.points,
+      RouteEquipment.clean,
+    );
+
+    expect(underTest.convert(entity) == expected, true);
+  });
+  test(
+      'Conversion attempt from a Route where the equipment type is not filled properly shall fail.',
+      () {
+    underTest = RouteToRouteDtoConverter();
+    Route entity = TestUtils.createRoute(quantity: 1).first;
+    entity.equipment = "";
+
+    expect(
+      () => underTest.convert(entity),
+      throwsA(predicate((e) {
+        if (e is Exception) {
+          return e
+              .toString()
+              .contains("Unknown route equipment: ${entity.equipment}");
+        }
+        return false;
+      })),
+    );
   });
 }


### PR DESCRIPTION
### Depends on:
- [x] #114 
- [x] update database with the corresponding field(s), since lacking equipment info for a route could cause misbehaviours