### PR TITLE
#133 - harvest the capability of ordinals for sectors, walls and routes

### DIFF
--- a/lib/data/models/route.dart
+++ b/lib/data/models/route.dart
@@ -1,5 +1,5 @@
-import 'package:kisgeri24/data/models/entity.dart';
-import 'package:kisgeri24/data/models/init_values.dart';
+import "package:kisgeri24/data/models/entity.dart";
+import "package:kisgeri24/data/models/init_values.dart";
 
 class Route extends Entity {
   String name;
@@ -32,51 +32,50 @@ class Route extends Entity {
         equipment = equipment ?? unsetString,
         diffchanger = diffchanger ?? unsetString;
 
-  static Route fromSnapshot(value) {
-    Map routeMap = value as Map<dynamic, dynamic>;
+  static Route fromSnapshot(Map<String, dynamic> value) {
     String name = unsetString;
     String id = unsetString;
     double points = 0.0;
     int length = 0;
-    int keyHere = 0;
+    int routeKey = 0;
     int ordinal = unsetInt;
     int difficulty = 0;
     String equipment = unsetString;
     String diffchanger = unsetString;
 
-    routeMap.forEach((key, value) {
-      if (key == 'name') {
+    value.forEach((key, value) {
+      if (key == "name") {
         name = value;
-      } else if (key == 'id') {
+      } else if (key == "id") {
         id = value;
-      } else if (key == 'points') {
+      } else if (key == "points") {
         points = (value as int).toDouble();
-      } else if (key == 'length') {
+      } else if (key == "length") {
         length = value;
-      } else if (key == 'key') {
-        keyHere = value;
-      } else if (value == "ordinal") {
+      } else if (key == "key") {
+        routeKey = value;
+      } else if (key == "ordinal") {
         ordinal = value as int;
-      } else if (key == 'difficulty') {
+      } else if (key == "difficulty") {
         difficulty = value;
-      } else if (key == 'equipment') {
+      } else if (key == "equipment") {
         equipment = value;
-      } else if (key == 'diffchanger') {
+      } else if (key == "diffchanger") {
         diffchanger = value;
       }
     });
 
-    Route route = Route(
-        name: name,
-        id: id,
-        points: points,
-        length: length,
-        key: keyHere,
-        ordinal: ordinal,
-        difficulty: difficulty,
-        equipment: equipment,
-        diffchanger: diffchanger);
-    return route;
+    return Route(
+      name: name,
+      id: id,
+      points: points,
+      length: length,
+      key: routeKey,
+      ordinal: ordinal,
+      difficulty: difficulty,
+      equipment: equipment,
+      diffchanger: diffchanger,
+    );
   }
 
   @override

--- a/lib/services/sector_service.dart
+++ b/lib/services/sector_service.dart
@@ -11,26 +11,37 @@ class SectorService {
 
   SectorService(this.repository, this.sectorConverter);
 
-  Future<List<String>> getSectorNames() async {
+  Future<List<String>> getSectorNames({bool ordered = false}) async {
     logger.i("Collecting sector names");
-    List<String> sectorNames = [];
-    List<SectorDto> sectors = await getSectorsWithRoutes();
-    for (SectorDto sector in sectors) {
+    final List<String> sectorNames = [];
+    final List<SectorDto> sectors =
+        await getSectorsWithRoutes(ordered: ordered);
+    for (final SectorDto sector in sectors) {
       sectorNames.add(sector.name);
     }
     logger.i("${sectorNames.length} sector name got collected");
     return sectorNames;
   }
 
-  Future<List<SectorDto>> getSectorsWithRoutes() async {
+  Future<List<SectorDto>> getSectorsWithRoutes({bool ordered = false}) async {
     logger.i("Collecting Sectors with their route info.");
-    List<Sector> sectorsFromDb = await repository.fetchAll();
+    final List<Sector> sectorsFromDb = await repository.fetchAll();
     logger.i("${sectorsFromDb.length} sector(s) got collected.");
     if (sectorsFromDb.isNotEmpty) {
       logger.i("Converting ${sectorsFromDb.length} Sector(s) to Sector DTO(s)");
-      List<SectorDto> sectors = [];
-      for (Sector sector in sectorsFromDb) {
+      final List<SectorDto> sectors = [];
+      for (final Sector sector in sectorsFromDb) {
         sectors.add(sectorConverter.convert(sector));
+      }
+      if (ordered) {
+        logger.d("Ordering sectors and their walls and routes");
+        for (final sector in sectors) {
+          for (final wall in sector.walls) {
+            wall.routes.sort((a, b) => a.ordinal.compareTo(b.ordinal));
+          }
+          sector.walls.sort((a, b) => a.ordinal.compareTo(b.ordinal));
+        }
+        sectors.sort((a, b) => a.ordinal.compareTo(b.ordinal));
       }
       return sectors;
     } else {

--- a/test/services/sector_service_test.dart
+++ b/test/services/sector_service_test.dart
@@ -1,8 +1,12 @@
 @GenerateNiceMocks([MockSpec<SectorToSectorDtoConverter>()])
 import "package:kisgeri24/data/converter/sector_sector_dto_converter.dart";
 import "package:kisgeri24/data/dto/sector_dto.dart";
+import "package:kisgeri24/data/dto/route_equipment.dart";
+import "package:kisgeri24/data/dto/wall_dto.dart";
+import "package:kisgeri24/data/dto/route_dto.dart";
 import "package:kisgeri24/data/models/route.dart";
 import "package:kisgeri24/data/models/sector.dart";
+import "package:kisgeri24/data/models/wall.dart";
 @GenerateNiceMocks([MockSpec<SectorRepository>()])
 import "package:kisgeri24/data/repositories/sector_repository.dart";
 import "package:kisgeri24/services/sector_service.dart";
@@ -24,6 +28,10 @@ void main() {
 
   testGetSectorsWithRoutesNoSector();
   testGetSectorsWithRoutesNoSector();
+
+  testGetSectorsMultipleSectorsOrdered();
+  testGetSectorsSingleSectorMultipleWallsOrdered();
+  testGetSectorsSingleSectorMultipleRoutesOrdered();
 }
 
 void testGetSectorNamesWhenNoSectorComingBackFromDatabase() {
@@ -135,6 +143,124 @@ void testGetSectorsWithRoutesMultipleSector() {
     expect(result != null, true);
     expect(result.length, sectorFromDb.length);
     expect(result, sectorFromDb.map((sector) => sector.name).toList());
+  });
+}
+
+void testGetSectorsMultipleSectorsOrdered() {
+  configure();
+  test(
+      "Test getSectorsWithRoutes when ordered is true and multiple sectors are there",
+      () async {
+    List<Sector> sectorFromDb = [
+      new Sector("testSectorName-1", testOrdinal, List.empty(),
+          TestUtils.createRoute()),
+      new Sector("testSectorName-2", testOrdinal + 1, List.empty(),
+          TestUtils.createRoute(quantity: 2))
+    ];
+    when(mockSectorToSectorDtoConverter.convert(sectorFromDb[0]))
+        .thenReturn(SectorDto(sectorFromDb[0].name, testOrdinal, List.empty()));
+    when(mockSectorToSectorDtoConverter.convert(sectorFromDb[1])).thenReturn(
+        SectorDto(sectorFromDb[1].name, testOrdinal + 1, List.empty()));
+    when(mockSectorRepository.fetchAll())
+        .thenAnswer((_) async => Future.value(sectorFromDb));
+
+    List<SectorDto> result =
+        await underTest.getSectorsWithRoutes(ordered: true);
+
+    expect(result != null, true);
+    expect(result.length, sectorFromDb.length);
+    expect(result[0].name, sectorFromDb[0].name);
+    expect(result[1].name, sectorFromDb[1].name);
+  });
+}
+
+void testGetSectorsSingleSectorMultipleRoutesOrdered() {
+  configure();
+  test(
+      "Test getSectorsWithRoutes when ordered is true and a single sector is there with one wall and multiple routes",
+      () async {
+    List<Sector> sectorFromDb = [
+      new Sector(
+        "testSectorName-1",
+        testOrdinal,
+        TestUtils.createWall(quantity: 1, routeQuantity: 2),
+        List.empty(),
+      ),
+    ];
+    when(mockSectorToSectorDtoConverter.convert(sectorFromDb[0]))
+        .thenReturn(SectorDto(sectorFromDb[0].name, testOrdinal, [
+      WallDto(
+        sectorFromDb[0].walls![0].name,
+        sectorFromDb[0].walls![0].ordinal,
+        [
+          RouteDto(
+            sectorFromDb[0].walls![0].routes[0].name,
+            sectorFromDb[0].walls![0].routes[0].ordinal,
+            sectorFromDb[0].walls![0].routes[0].difficulty.toString(),
+            sectorFromDb[0].walls![0].routes[0].points,
+            RouteEquipment.fromString(
+                sectorFromDb[0].walls![0].routes[0].equipment),
+          ),
+          RouteDto(
+            sectorFromDb[0].walls![0].routes[1].name,
+            sectorFromDb[0].walls![0].routes[1].ordinal,
+            sectorFromDb[0].walls![0].routes[1].difficulty.toString(),
+            sectorFromDb[0].walls![0].routes[1].points,
+            RouteEquipment.fromString(
+                sectorFromDb[0].walls![0].routes[1].equipment),
+          ),
+        ],
+      )
+    ]));
+    when(mockSectorRepository.fetchAll())
+        .thenAnswer((_) async => Future.value(sectorFromDb));
+
+    List<SectorDto> result =
+        await underTest.getSectorsWithRoutes(ordered: true);
+
+    expect(result != null, true);
+    expect(result[0].walls[0].routes[0].name,
+        sectorFromDb[0].walls![0].routes[0].name);
+    expect(result[0].walls[0].routes[1].name,
+        sectorFromDb[0].walls![0].routes[1].name);
+  });
+}
+
+void testGetSectorsSingleSectorMultipleWallsOrdered() {
+  configure();
+  test(
+      "Test getSectorsWithRoutes when ordered is true and a single sector is there with multiple walls and no routes",
+      () async {
+    List<Sector> sectorFromDb = [
+      new Sector(
+        "testSectorName-1",
+        testOrdinal,
+        TestUtils.createWall(quantity: 2, routeQuantity: 0),
+        List.empty(),
+      ),
+    ];
+    when(mockSectorToSectorDtoConverter.convert(sectorFromDb[0]))
+        .thenReturn(SectorDto(sectorFromDb[0].name, testOrdinal, [
+      WallDto(
+        sectorFromDb[0].walls![0].name,
+        sectorFromDb[0].walls![0].ordinal,
+        List.empty(),
+      ),
+      WallDto(
+        sectorFromDb[0].walls![1].name,
+        sectorFromDb[0].walls![1].ordinal,
+        List.empty(),
+      )
+    ]));
+    when(mockSectorRepository.fetchAll())
+        .thenAnswer((_) async => Future.value(sectorFromDb));
+
+    List<SectorDto> result =
+        await underTest.getSectorsWithRoutes(ordered: true);
+
+    expect(result != null, true);
+    expect(result[0].walls[0].name, sectorFromDb[0].walls![0].name);
+    expect(result[0].walls[1].name, sectorFromDb[0].walls![1].name);
   });
 }
 

--- a/test/test_utils/test_utils.dart
+++ b/test/test_utils/test_utils.dart
@@ -66,18 +66,20 @@ class TestUtils {
         name: "route-$i",
         ordinal: i,
         points: quantity * 100,
+        equipment:
+            RouteEquipment.values[i % RouteEquipment.values.length].shorthand,
       ));
     }
     return routes;
   }
 
-  static List<Wall> createWall({int quantity = 1}) {
+  static List<Wall> createWall({int quantity = 1, int routeQuantity = 1}) {
     List<Wall> walls = [];
     for (int i = 0; i < quantity; i++) {
       walls.add(new Wall(
         name: "wall-$i",
         ordinal: i,
-        routes: createRoute(quantity: 1),
+        routes: createRoute(quantity: routeQuantity),
       ));
     }
     return walls;


### PR DESCRIPTION
- It also fixes an issue where the route ordinal wasn't filled upon entity creation due to a misconfigured condition